### PR TITLE
Add Meta Pixel tracking code

### DIFF
--- a/watchyourtemper-site/index.html
+++ b/watchyourtemper-site/index.html
@@ -18,12 +18,12 @@
       fbq('init', '1091351883191425');
       fbq('track', 'PageView');
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=1091351883191425&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Meta Pixel Code -->
   </head>
   <body>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=1091351883191425&ev=PageView&noscript=1"
+    /></noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/watchyourtemper-site/index.html
+++ b/watchyourtemper-site/index.html
@@ -5,6 +5,23 @@
     <link rel="icon" type="image/png" href="/wyt.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>watchyourtemper.</title>
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1091351883191425');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=1091351883191425&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel Code -->
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- embed Meta Pixel base script in site head to track PageView events across all routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5a427c74c83278a49be6c11d4e840