### PR TITLE
Reorder bandcamp link to top of machine page

### DIFF
--- a/watchyourtemper-site/src/pages/FeedTheMachine.tsx
+++ b/watchyourtemper-site/src/pages/FeedTheMachine.tsx
@@ -21,6 +21,10 @@ const FeedTheMachine: React.FC = () => {
           <p className="machine-sub">CHOOSE YOUR WEAPON</p>
 
           <div className="machine-links">
+            <a className="feed-btn" href="https://watchyourtemper.bandcamp.com" target="_blank">
+              <img src="/icons/bandcamp.png" alt="Bandcamp" className="btn-icon" />
+              BANDCAMP
+            </a>
             <a className="feed-btn" href="https://open.spotify.com/artist/4J2nrkMqpsfDQcZgSalbht?si=0BOws4dHSginwoO28iy90A" target="_blank">
               <img src="/icons/spotify.png" alt="Spotify" className="btn-icon" />
               SPOTIFY
@@ -36,10 +40,6 @@ const FeedTheMachine: React.FC = () => {
             <a className="feed-btn" href="https://tidal.com/browse/artist/50451699?u" target="_blank">
               <img src="/icons/tidal.png" alt="Tidal" className="btn-icon" />
               TIDAL
-            </a>
-            <a className="feed-btn" href="https://watchyourtemper.bandcamp.com" target="_blank">
-              <img src="/icons/bandcamp.png" alt="Bandcamp" className="btn-icon" />
-              BANDCAMP
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move the Bandcamp link to the top of the machine page link list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f10a1b68488327a9f6e0f54f089698