### PR TITLE
Add minimal frontend-only Store page with Stripe Payment Links

### DIFF
--- a/watchyourtemper-site/README.md
+++ b/watchyourtemper-site/README.md
@@ -95,6 +95,26 @@ This site links to a private supporters' mailing list through [MailerLite](https
 
 ---
 
+
+## 🛒 Store (Stripe Payment Links)
+
+The merch store is frontend-only and uses hosted Stripe Payment Links.
+
+- Edit product data in `src/data/storeProducts.ts`.
+- Paste each Stripe URL into `stripeUrl` and set `enabled: true` for products you want live.
+- Add product images to `public/assets/images/store/` and set each product `image` path (example: `/assets/images/store/watchyourtemper-tee.jpg`).
+- Store UI route/page lives at `src/pages/Store.tsx` and is available at `/store`.
+
+Files changed for this feature:
+- `src/data/storeProducts.ts`
+- `src/pages/Store.tsx`
+- `src/App.tsx`
+- `src/components/Navbar.tsx`
+- `src/styles/index.css`
+- `README.md`
+
+---
+
 ## 📦 Deployment
 
 Recommended: [Vercel](https://vercel.com/) or [Netlify](https://netlify.com/)

--- a/watchyourtemper-site/src/App.tsx
+++ b/watchyourtemper-site/src/App.tsx
@@ -4,6 +4,7 @@ import AudioPlayer from './components/AudioPlayer';
 import Home from './pages/Home';
 import FeedTheMachine from './pages/FeedTheMachine';
 import Join from './pages/Join';
+import Store from './pages/Store';
 
 const App: React.FC = () => {
   return (
@@ -15,6 +16,7 @@ const App: React.FC = () => {
         <Route path="/" element={<Home />} />
         <Route path="/machine" element={<FeedTheMachine />} />
         <Route path="/join" element={<Join />} />
+        <Route path="/store" element={<Store />} />
       </Routes>
     </Router>
   );

--- a/watchyourtemper-site/src/components/Navbar.tsx
+++ b/watchyourtemper-site/src/components/Navbar.tsx
@@ -17,6 +17,7 @@ const Navbar: React.FC = () => {
         </Link>
       </div>
       <div className="nav-right">
+        <Link to="/store">STORE</Link>
         <a href="/join"
            target="_blank"
            rel="noopener noreferrer"
@@ -58,6 +59,8 @@ const Navbar: React.FC = () => {
       <div className={`mobile-menu ${menuOpen ? "show" : ""}`}>
         <Link to="/">home</Link>
         <Link to="/machine">machine</Link>
+        <Link to="/store">store</Link>
+        <Link to="/join">join</Link>
       </div>
     </div>
   );

--- a/watchyourtemper-site/src/data/storeProducts.ts
+++ b/watchyourtemper-site/src/data/storeProducts.ts
@@ -1,0 +1,59 @@
+export type StoreProduct = {
+  id: string;
+  name: string;
+  description: string;
+  price: string;
+  variant?: string;
+  image?: string;
+  stripeUrl: string;
+  enabled: boolean;
+};
+
+// TODO: Replace placeholder values with your real merch product details.
+// - name: product title
+// - description: short product description
+// - price: display text only (for example "$35 CAD")
+// - image: path to image under /public/assets/images/store/
+// - stripeUrl: Stripe Payment Link URL (https://buy.stripe.com/...)
+export const storeProducts: StoreProduct[] = [
+  {
+    id: 'watchyourtemper-tee',
+    name: 'WATCHYOURTEMPER Tee',
+    description: 'Heavyweight black tee with front print placeholder.',
+    price: '$00.00', // TODO: replace with real price text
+    variant: 'Unisex / S-XXL',
+    image: '', // TODO: e.g. /assets/images/store/watchyourtemper-tee.jpg
+    stripeUrl: '', // TODO: paste Stripe Payment Link URL
+    enabled: false,
+  },
+  {
+    id: 'watchyourtemper-tote',
+    name: 'WATCHYOURTEMPER Tote',
+    description: 'Canvas tote placeholder for everyday carry.',
+    price: '$00.00', // TODO: replace with real price text
+    variant: 'One Size',
+    image: '', // TODO: e.g. /assets/images/store/watchyourtemper-tote.jpg
+    stripeUrl: '', // TODO: paste Stripe Payment Link URL
+    enabled: false,
+  },
+  {
+    id: 'pressure-test-tee',
+    name: 'PRESSURE TEST Tee',
+    description: 'Short sleeve tee placeholder with PRESSURE TEST artwork.',
+    price: '$00.00', // TODO: replace with real price text
+    variant: 'Unisex / S-XXL',
+    image: '', // TODO: e.g. /assets/images/store/pressure-test-tee.jpg
+    stripeUrl: '', // TODO: paste Stripe Payment Link URL
+    enabled: false,
+  },
+  {
+    id: 'pressure-test-poster',
+    name: 'PRESSURE TEST Poster',
+    description: 'Limited poster placeholder print.',
+    price: '$00.00', // TODO: replace with real price text
+    variant: '18 x 24 in',
+    image: '', // TODO: e.g. /assets/images/store/pressure-test-poster.jpg
+    stripeUrl: '', // TODO: paste Stripe Payment Link URL
+    enabled: false,
+  },
+];

--- a/watchyourtemper-site/src/pages/Store.tsx
+++ b/watchyourtemper-site/src/pages/Store.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { storeProducts } from '../data/storeProducts';
+import '../styles/index.css';
+
+const Store: React.FC = () => {
+  useEffect(() => {
+    document.title = 'WATCHYOURTEMPER | Store';
+  }, []);
+
+  return (
+    <main className="store-page">
+      <section className="store-header">
+        <h1 className="store-title">STORE</h1>
+        <p className="store-subtitle">Official merch. Stripe checkout. No cart.</p>
+      </section>
+
+      <section className="store-grid" aria-label="Store products">
+        {storeProducts.map((product) => {
+          const hasImage = Boolean(product.image);
+          const canBuy = product.enabled && Boolean(product.stripeUrl);
+
+          return (
+            <article key={product.id} className="store-card">
+              {hasImage ? (
+                <img className="store-image" src={product.image} alt={product.name} />
+              ) : (
+                <div className="store-image-placeholder" aria-label="Product image placeholder">
+                  ADD IMAGE IN /public/assets/images/store/
+                </div>
+              )}
+
+              <div className="store-card-body">
+                <h2 className="store-product-name">{product.name}</h2>
+                <p className="store-product-description">{product.description}</p>
+                {product.variant ? <p className="store-product-variant">{product.variant}</p> : null}
+                <p className="store-product-price">{product.price}</p>
+              </div>
+
+              {canBuy ? (
+                <a
+                  href={product.stripeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="store-buy-btn"
+                >
+                  Buy now
+                </a>
+              ) : (
+                <button className="store-buy-btn disabled" type="button" disabled>
+                  Coming soon
+                </button>
+              )}
+            </article>
+          );
+        })}
+      </section>
+    </main>
+  );
+};
+
+export default Store;

--- a/watchyourtemper-site/src/styles/index.css
+++ b/watchyourtemper-site/src/styles/index.css
@@ -693,3 +693,111 @@ h2 {
   text-shadow: 1px 0 #00f9ff;
   animation: glitch-cyan-intense 0.35s infinite steps(2, end);
 }
+
+.store-page {
+  min-height: 100vh;
+  padding: 7rem 1.5rem 3rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.store-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.store-title {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  letter-spacing: 0.08em;
+  animation: flicker 2.5s infinite;
+}
+
+.store-subtitle {
+  margin-top: 0.5rem;
+  color: #bdbdbd;
+  font-size: 0.85rem;
+}
+
+.store-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.store-card {
+  border: 1px solid #2a2a2a;
+  background: rgba(0, 0, 0, 0.85);
+  padding: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.store-image,
+.store-image-placeholder {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+}
+
+.store-image {
+  object-fit: cover;
+  border: 1px solid #222;
+}
+
+.store-image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #555;
+  color: #8f8f8f;
+  font-size: 0.72rem;
+  text-align: center;
+  padding: 0.75rem;
+}
+
+.store-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.store-product-name {
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+}
+
+.store-product-description,
+.store-product-variant {
+  font-size: 0.8rem;
+  color: #c3c3c3;
+  margin: 0;
+}
+
+.store-product-price {
+  margin: 0.2rem 0 0;
+  font-size: 0.95rem;
+}
+
+.store-buy-btn {
+  margin-top: auto;
+  border: 1px solid #a42117;
+  color: #ffffff;
+  background: transparent;
+  padding: 0.55rem 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-family: inherit;
+  text-align: center;
+  cursor: pointer;
+}
+
+.store-buy-btn:hover {
+  background: rgba(164, 33, 23, 0.15);
+}
+
+.store-buy-btn.disabled,
+.store-buy-btn:disabled {
+  border-color: #555;
+  color: #8f8f8f;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, frontend-only merch storefront that preserves the existing site and design system. 
- Keep the implementation minimal so hosted Stripe Payment Links can be used for checkout with no backend, cart, or order logic. 

### Description
- Add a single editable product config at `src/data/storeProducts.ts` with 4 placeholder products and clear `TODO` comments for `stripeUrl`, `image`, `price`, and `enabled` flags. 
- Add a new page `src/pages/Store.tsx` that renders the products in a responsive grid, shows a clear image placeholder when no image is provided, and exposes a `Buy now` link that opens each product's Stripe Payment Link in a new tab (or a disabled `Coming soon` button when `stripeUrl`/`enabled` is missing). 
- Wire the route into the existing router by adding `/store` in `src/App.tsx` and add a `STORE` link to desktop and mobile navigation in `src/components/Navbar.tsx`. 
- Add lightweight store styles to `src/styles/index.css` matching existing aesthetics and update `README.md` with short documentation on where to edit products, add images, and paste Stripe links. 

### Testing
- Run the production build with `npm run build`, which completed successfully (TypeScript compile + Vite build). 
- No backend tests or unit tests were added; this change was validated by the successful build only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd46322edc8327816bd2f6e51f65db)