### PR TITLE
Use looping muted YouTube video as home background

### DIFF
--- a/watchyourtemper-site/src/pages/Home.tsx
+++ b/watchyourtemper-site/src/pages/Home.tsx
@@ -1,14 +1,25 @@
 import '../styles/index.css';
 import { useNavigate } from 'react-router-dom';
 
-
 const Home: React.FC = () => {
   const navigate = useNavigate();
+  const backgroundVideoId = 'hvVGt5L7_tM';
+
   return (
     <div className="home-container">
-      <div className="bg-burying" />
+      <div className="video-background" aria-hidden="true">
+        <iframe
+          className="video-background-iframe"
+          src={`https://www.youtube-nocookie.com/embed/${backgroundVideoId}?autoplay=1&mute=1&controls=0&loop=1&playlist=${backgroundVideoId}&playsinline=1&rel=0&modestbranding=1&iv_load_policy=3&disablekb=1`}
+          title="Background video"
+          allow="autoplay; fullscreen; picture-in-picture"
+          tabIndex={-1}
+        />
+      </div>
       <div className="overlay">
-        <h1 className="glitch-link" data-text="feed the machine" onClick={() => navigate('/machine')}>feed the machine</h1>
+        <h1 className="glitch-link" data-text="feed the machine" onClick={() => navigate('/machine')}>
+          feed the machine
+        </h1>
       </div>
     </div>
   );

--- a/watchyourtemper-site/src/styles/index.css
+++ b/watchyourtemper-site/src/styles/index.css
@@ -325,12 +325,25 @@ h2 {
   overflow: hidden;
 }
 
-.bg-burying {
-  background: url("/images/wyt-burying-5b.png") center/cover no-repeat fixed;
-  filter: brightness(0.65) contrast(1.2);
+.video-background {
   position: absolute;
   inset: 0;
   z-index: -2;
+  overflow: hidden;
+  filter: brightness(0.65) contrast(1.2);
+  pointer-events: none;
+}
+
+.video-background-iframe {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 177.78vh;
+  min-width: 100%;
+  height: 56.25vw;
+  min-height: 100%;
+  transform: translate(-50%, -50%);
+  border: 0;
 }
 
 .overlay {


### PR DESCRIPTION
### Motivation
- Replace the static background image on the Home page with a continuously-playing, muted video so the site has a moving background that makes no noise.

### Description
- Replaced the `.bg-burying` static background with a `video-background` wrapper containing a YouTube iframe embed using the provided video ID (`hvVGt5L7_tM`) and the `youtube-nocookie` domain.
- Configured the iframe `src` to autoplay, be muted, hide controls, loop, and suppress related-video UI (`autoplay=1&mute=1&controls=0&loop=1&playlist=...&rel=0&modestbranding=1`).
- Added `.video-background` and `.video-background-iframe` CSS to center/scale the embed so it covers the viewport like a background and set `pointer-events: none` so overlay content remains interactive.
- Updated `src/pages/Home.tsx` and `src/styles/index.css` to implement the above changes.

### Testing
- Ran `cd watchyourtemper-site && npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4a1418f88327bd3e426829a0b1fd)