### PR TITLE
Refactor layout offsets: home overlay nav and fluid store grid

### DIFF
--- a/watchyourtemper-site/src/App.tsx
+++ b/watchyourtemper-site/src/App.tsx
@@ -1,22 +1,36 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import AudioPlayer from './components/AudioPlayer';
 import Home from './pages/Home';
 import FeedTheMachine from './pages/FeedTheMachine';
 import Join from './pages/Join';
 import Store from './pages/Store';
+import './styles/index.css';
+
+const AppLayout: React.FC = () => {
+  const location = useLocation();
+  const isHomeRoute = location.pathname === '/';
+
+  return (
+    <>
+      <AudioPlayer />
+      <Navbar variant={isHomeRoute ? 'overlay' : 'solid'} />
+      <div className={`route-shell ${isHomeRoute ? 'route-shell--overlay' : ''}`}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/machine" element={<FeedTheMachine />} />
+          <Route path="/join" element={<Join />} />
+          <Route path="/store" element={<Store />} />
+        </Routes>
+      </div>
+    </>
+  );
+};
 
 const App: React.FC = () => {
   return (
     <Router>
-      <AudioPlayer />
-      <Navbar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/machine" element={<FeedTheMachine />} />
-        <Route path="/join" element={<Join />} />
-        <Route path="/store" element={<Store />} />
-      </Routes>
+      <AppLayout />
     </Router>
   );
 };

--- a/watchyourtemper-site/src/components/Navbar.tsx
+++ b/watchyourtemper-site/src/components/Navbar.tsx
@@ -1,13 +1,18 @@
-import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import "../styles/index.css";
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import '../styles/index.css';
 
-const Navbar: React.FC = () => {
+type NavbarVariant = 'overlay' | 'solid';
+
+interface NavbarProps {
+  variant: NavbarVariant;
+}
+
+const Navbar: React.FC<NavbarProps> = ({ variant }) => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const location = useLocation();
-  const isHome = location.pathname === "/";
+
   return (
-    <nav className={`nav-top ${!isHome ? "nav-solid" : ""}`}>
+    <nav className={`nav-top ${variant === 'solid' ? 'nav-solid' : ''}`}>
       <div className="nav-left">
         <Link to="/">
           <img
@@ -19,10 +24,9 @@ const Navbar: React.FC = () => {
       </div>
       <div className="nav-right">
         <Link to="/store">STORE</Link>
-        <a href="/join"
-           target="_blank"
-           rel="noopener noreferrer"
-           >JOIN</a>
+        <a href="/join" target="_blank" rel="noopener noreferrer">
+          JOIN
+        </a>
         <a
           href="https://www.instagram.com/watchyourtemper/"
           target="_blank"
@@ -57,7 +61,7 @@ const Navbar: React.FC = () => {
         <span />
         <span />
       </button>
-      <div className={`mobile-menu ${menuOpen ? "show" : ""}`}>
+      <div className={`mobile-menu ${menuOpen ? 'show' : ''}`}>
         <Link to="/" onClick={() => setMenuOpen(false)}>
           home
         </Link>

--- a/watchyourtemper-site/src/index.css
+++ b/watchyourtemper-site/src/index.css
@@ -1,68 +1,7 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: rgba(125, 255, 136, 0.55);
-  text-decoration: inherit;
-}
-a:hover {
-  color: rgba(125, 255, 136, 0.55);
-}
-
-body {
+html,
+body,
+#root {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  width: 100%;
+  min-height: 100%;
 }

--- a/watchyourtemper-site/src/styles/index.css
+++ b/watchyourtemper-site/src/styles/index.css
@@ -12,6 +12,16 @@
   --nav-height-mobile: 68px;
 }
 
+.route-shell {
+  --nav-offset: var(--nav-height);
+  min-height: 100dvh;
+  padding-top: var(--nav-offset);
+}
+
+.route-shell--overlay {
+  padding-top: 0;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -677,27 +687,20 @@ h2 {
   --panel-border: #242424;
   --panel-inline: #111;
   --log-text: #8d8d8d;
-  min-height: 100vh;
-  width: 100%;
-  max-width: 1800px;
+  min-height: calc(100dvh - var(--nav-offset));
+  width: min(100%, 2200px);
   margin: 0 auto;
-  padding: calc(var(--nav-height) + 1.5rem) 2rem 3rem;
+  padding: 1.5rem clamp(1rem, 2.5vw, 3rem) 3rem;
   box-sizing: border-box;
   position: relative;
   isolation: isolate;
 }
 
-.store-nav-spacer {
-  height: calc(var(--nav-height) + 1.5rem);
-  width: 100%;
-  flex: 0 0 auto;
-}
-
 .store-grid {
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
+  gap: clamp(1rem, 1.5vw, 1.5rem);
   align-items: start;
 }
 
@@ -1023,33 +1026,12 @@ h2 {
   }
 }
 
-@media screen and (min-width: 1600px) {
-  .store-page {
-    max-width: 2200px;
-    padding-left: 3rem;
-    padding-right: 3rem;
-  }
-
-  .store-nav-spacer {
-    height: calc(var(--nav-height) + 1.5rem);
-  }
-
-  .store-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-
 @media screen and (max-width: 768px) {
+  .route-shell {
+    --nav-offset: var(--nav-height-mobile);
+  }
+
   .store-page {
-    padding: calc(var(--nav-height-mobile) + 1.5rem) 1rem 2rem;
-  }
-
-  .store-nav-spacer {
-    height: calc(var(--nav-height-mobile) + 1.5rem);
-  }
-
-  .store-grid {
-    grid-template-columns: 1fr;
-    gap: 1rem;
+    padding-bottom: 2rem;
   }
 }


### PR DESCRIPTION
### Motivation
- The home hero/video was being pushed down by global starter CSS and multiple competing offset systems, producing a black gap above the hero and preventing the navbar from properly overlaying the hero.  
- The Store page used per-page padding and a `.store-nav-spacer` plus breakpoint-driven grid rules (`3-cols` then `4-cols @1600px`), which caused content overlap and brittle layout behavior at non-target widths.  
- Navbar behavior and route-specific spacing logic were mixed across components and page CSS instead of being resolved by a single route-aware layout layer.

### Description
- Introduced a route-aware `AppLayout` that controls navbar variant and top-offset behavior centrally so pages opt-in or out of nav overlay via a single wrapper (`src/App.tsx`).
- Made `Navbar` accept an explicit `variant` prop (`overlay` | `solid`) and removed route-detection from the component so the layout drives appearance (`src/components/Navbar.tsx`).
- Added a shared `.route-shell` / `.route-shell--overlay` CSS pattern and removed the legacy global centering rules, moving navbar clearance to the shared layout and letting Home opt out (so the hero starts at the top) (`src/styles/index.css`, `src/index.css`).
- Reworked Store styling to remove duplicate nav-offset hacks and the 1600px-specific breakpoint, swapping the brittle fixed columns for a fluid `auto-fit`/`minmax()` grid and responsive padding so cards auto-fit cleanly across widths (`src/styles/index.css`).

### Testing
- Ran `npm run build` in the site: build completed successfully.  
- Ran `npm run lint`: linter completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd817cb33083278fe84360ef6d5190)