### PR TITLE
Fix mobile navbar collapse and toxic-green hover accents

### DIFF
--- a/watchyourtemper-site/src/components/Navbar.tsx
+++ b/watchyourtemper-site/src/components/Navbar.tsx
@@ -56,7 +56,13 @@ const Navbar: React.FC<NavbarProps> = ({ variant }) => {
           <img src="/icons/soundcloud.svg" alt="SC" className="social-icon" />
         </a>
       </div>
-      <button className="burger" onClick={() => setMenuOpen(!menuOpen)}>
+      <button
+        className={`burger ${menuOpen ? 'is-open' : ''}`}
+        type="button"
+        aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={menuOpen}
+        onClick={() => setMenuOpen(!menuOpen)}
+      >
         <span />
         <span />
         <span />

--- a/watchyourtemper-site/src/styles/index.css
+++ b/watchyourtemper-site/src/styles/index.css
@@ -10,6 +10,7 @@
 :root {
   --nav-height: 76px;
   --nav-height-mobile: 68px;
+  --toxic-green: #7dff88;
 }
 
 .route-shell {
@@ -186,6 +187,15 @@ h2 {
 .burger:hover span {
   animation: rageShake 0.35s infinite;
   transform: scale(1.05);
+}
+
+.nav-top a:hover {
+  color: var(--toxic-green);
+  text-shadow: 0 0 6px rgba(125, 255, 136, 0.45);
+}
+
+.nav-top img:hover {
+  filter: drop-shadow(0 0 8px rgba(125, 255, 136, 0.55));
 }
 
 /* === SHAKE KEYFRAMES === */
@@ -1029,6 +1039,53 @@ h2 {
 @media screen and (max-width: 768px) {
   .route-shell {
     --nav-offset: var(--nav-height-mobile);
+  }
+
+  .nav-top {
+    height: var(--nav-height-mobile);
+    padding: 0 1rem;
+  }
+
+  .nav-right {
+    display: none;
+  }
+
+  .burger {
+    display: flex;
+  }
+
+  .burger:hover span,
+  .burger.is-open span {
+    background: var(--toxic-green);
+    box-shadow: 0 0 8px rgba(125, 255, 136, 0.55);
+  }
+
+  .mobile-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    width: 100%;
+    padding: 0.75rem 1rem 1rem;
+    background: rgba(0, 0, 0, 0.95);
+    border-top: 1px solid #151515;
+    border-bottom: 1px solid #151515;
+    flex-direction: column;
+    gap: 0.75rem;
+    z-index: 100;
+  }
+
+  .mobile-menu a {
+    color: #e9e9e9;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.9rem;
+    padding: 0.3rem 0;
+  }
+
+  .mobile-menu a:hover {
+    color: var(--toxic-green);
+    text-shadow: 0 0 6px rgba(125, 255, 136, 0.5);
   }
 
   .store-page {


### PR DESCRIPTION
### Motivation
- The navbar stopped collapsing on small screens which left desktop links visible and cluttered mobile layouts.
- Hover/accent states needed to match the requested toxic green aesthetic and provide clearer visual feedback.

### Description
- Added `type="button"`, `aria-label`, `aria-expanded`, and an `is-open` class hook to the burger button in `watchyourtemper-site/src/components/Navbar.tsx` to improve semantics and enable styling when open.
- Introduced `--toxic-green` and toxic-green hover treatments for navbar links and images in `watchyourtemper-site/src/styles/index.css` to provide the requested accent color and glow.
- Restored responsive behavior under `@media (max-width: 768px)` in `watchyourtemper-site/src/styles/index.css` to hide `.nav-right`, show the `.burger`, and position/style the `.mobile-menu` so the navbar collapses into a usable mobile menu.

### Testing
- Ran `npm run build` in the `watchyourtemper-site` directory and the production build completed successfully.
- No automated unit tests were present or run beyond the build step; the build verification passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8376619083279f31aa5544cf275f)