### PR TITLE
docs: outline secure Printful API migration path

### DIFF
--- a/watchyourtemper-site/README.md
+++ b/watchyourtemper-site/README.md
@@ -96,14 +96,21 @@ This site links to a private supporters' mailing list through [MailerLite](https
 ---
 
 
-## 🛒 Store (Stripe Payment Links)
+## 🛒 Store (Stripe now, Printful API-ready path)
 
-The merch store is frontend-only and uses hosted Stripe Payment Links.
+The current merch store is frontend-only and uses hosted Stripe Payment Links.
 
 - Edit product data in `src/data/storeProducts.ts`.
 - Paste each Stripe URL into `stripeUrl` and set `enabled: true` for products you want live.
 - Add product images to `public/assets/images/store/` and set each product `image` path (example: `/assets/images/store/watchyourtemper-tee.jpg`).
 - Store UI route/page lives at `src/pages/Store.tsx` and is available at `/store`.
+
+### Printful API note
+
+You can integrate Printful, but **not directly from browser-only code** (API token exposure risk).
+Use a backend/serverless layer to create orders after successful checkout.
+
+See implementation notes in `docs-printful-integration.md`.
 
 Files changed for this feature:
 - `src/data/storeProducts.ts`

--- a/watchyourtemper-site/docs-printful-integration.md
+++ b/watchyourtemper-site/docs-printful-integration.md
@@ -1,0 +1,50 @@
+# Printful API Integration Plan (replacing Stripe Payment Links)
+
+Short answer: **yes, but not directly from the browser**.
+
+The current site is frontend-only and uses hosted Stripe Payment Links. Printful API tokens must be kept secret, so Printful calls need to happen in a backend function (serverless is fine).
+
+## Recommended flow
+
+1. Customer clicks **Buy** in the React app.
+2. Frontend calls your backend endpoint (e.g. `/api/checkout`).
+3. Backend creates payment intent/session with your payment provider.
+4. After payment succeeds, backend creates a Printful order via `POST /orders`.
+5. Backend stores order IDs and listens for Printful webhooks (fulfillment + tracking updates).
+6. Frontend shows confirmation and tracking status from your backend.
+
+## Why not fully direct-to-Printful?
+
+- Printful API is an order-fulfillment API, not a complete customer checkout UI.
+- API credentials must never be exposed in client code.
+- You still need customer payment handling, taxes, and fraud checks.
+
+## Minimal backend endpoints to add
+
+- `POST /api/checkout/start` - starts customer checkout.
+- `POST /api/checkout/confirm` - verifies payment success.
+- `POST /api/printful/orders` - creates Printful order after payment.
+- `POST /api/printful/webhooks` - receives fulfillment/tracking updates.
+
+## Data model additions
+
+In product data, keep:
+
+- `printfulVariantId`
+- `retailPrice`
+- `currency`
+- `enabled`
+
+In orders table, keep:
+
+- `paymentProviderOrderId`
+- `printfulOrderId`
+- `status`
+- `trackingNumber`
+- `trackingUrl`
+
+## Migration notes for this repo
+
+- Keep Stripe links temporarily to avoid downtime.
+- Add backend integration first, then swap Store buy buttons to your own `/checkout` route.
+- Remove `stripeUrl` only after successful end-to-end testing in sandbox.


### PR DESCRIPTION
### Motivation
- Provide a safe, backend-mediated migration path from the current frontend-only Stripe Payment Links store to a Printful order workflow while calling out security risks of exposing Printful API tokens in browser code.

### Description
- Added `docs-printful-integration.md` with a recommended flow (checkout → payment confirmation → `POST /orders` to Printful → webhook handling) and updated `README.md` store section to point to the new doc and note that Printful requires a server/backend; changes touch `watchyourtemper-site/README.md` and add `watchyourtemper-site/docs-printful-integration.md`.

### Testing
- Ran `npm run build` in the `watchyourtemper-site` project and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8b2ed58c832787220722d3354d87)