### PR TITLE
Store: add server-side Printful order support, Stripe checkout start, and client-side cart UI

### DIFF
--- a/watchyourtemper-site/README.md
+++ b/watchyourtemper-site/README.md
@@ -121,11 +121,17 @@ Copy `.env.example` and set values:
 - `GET /api/store/products/<id-or-slug>`
 - `POST /api/store/checkout-intent`
 
-### What remains for full live ordering
+### Lifecycle status (v2)
 
-- Connect checkout intents to your payment processor session/intent creation.
-- On successful payment, create real Printful orders server-side.
-- Add webhook handlers for fulfillment/tracking sync.
+- `POST /api/store/checkout-start` creates a Stripe Checkout Session from server-validated line-item data.
+- `POST /api/webhooks/payment` confirms Stripe webhooks and creates Printful orders.
+- `POST /api/webhooks/printful` syncs fulfillment/tracking updates back to checkout records.
+
+### Pricing source of truth
+
+- Variant prices are read from Printful product data (`retail_price`) and normalized server-side.
+- Checkout amounts are calculated on the server from the selected variant + quantity (browser price input is ignored).
+- Stripe Checkout `unit_amount` is derived from the server-validated variant price to avoid client-side tampering.
 
 ---
 

--- a/watchyourtemper-site/api/_lib/printfulClient.ts
+++ b/watchyourtemper-site/api/_lib/printfulClient.ts
@@ -37,6 +37,34 @@ type PrintfulProductDetail = {
   sync_variants: PrintfulSyncVariant[];
 };
 
+type PrintfulOrderRecipient = {
+  name: string;
+  address1: string;
+  address2?: string;
+  city: string;
+  state_code: string;
+  zip: string;
+  country_code: string;
+  email: string;
+};
+
+type PrintfulOrderItem = {
+  variant_id: number;
+  quantity: number;
+};
+
+type PrintfulCreateOrderInput = {
+  externalId: string;
+  recipient: PrintfulOrderRecipient;
+  items: PrintfulOrderItem[];
+};
+
+type PrintfulCreateOrderResult = {
+  id: number;
+  external_id?: string;
+  status?: string;
+};
+
 const parseVariantName = (name: string): { color: string; size: string } => {
   const parts = name.split('/').map((item) => item.trim()).filter(Boolean);
   if (parts.length >= 2) {
@@ -64,18 +92,23 @@ const getAccessToken = (): string => {
   return token;
 };
 
-const printfulRequest = async <T>(path: string): Promise<T> => {
+const printfulRequest = async <T>(input: {
+  path: string;
+  method?: 'GET' | 'POST';
+  body?: unknown;
+}): Promise<T> => {
   const token = getAccessToken();
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
   try {
-    const response = await fetch(`${PRINTFUL_API_BASE}${path}`, {
-      method: 'GET',
+    const response = await fetch(`${PRINTFUL_API_BASE}${input.path}`, {
+      method: input.method || 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
+      body: input.body ? JSON.stringify(input.body) : undefined,
       signal: controller.signal,
     });
 
@@ -124,15 +157,17 @@ const normalizeDetailedStoreProduct = (payload: PrintfulProductDetail) => {
   };
 };
 
+export const normalizeStoreProduct = normalizeDetailedStoreProduct;
+
 export const getStoreProducts = async () => {
-  const summaries = await printfulRequest<PrintfulProductListItem[]>('/store/products');
+  const summaries = await printfulRequest<PrintfulProductListItem[]>({ path: '/store/products' });
 
   const detailedProducts = await Promise.all(
     summaries
       .filter((item) => !item.is_ignored)
       .map(async (item) => {
         try {
-          const detail = await printfulRequest<PrintfulProductDetail>(`/store/products/${item.id}`);
+          const detail = await printfulRequest<PrintfulProductDetail>({ path: `/store/products/${item.id}` });
           return normalizeDetailedStoreProduct(detail);
         } catch (error) {
           console.error('[printful] failed to load product detail', item.id, error);
@@ -149,7 +184,7 @@ export const getStoreProducts = async () => {
 export const getStoreProductByIdOrSlug = async (idOrSlug: string) => {
   if (/^\d+$/.test(idOrSlug)) {
     try {
-      const detail = await printfulRequest<PrintfulProductDetail>(`/store/products/${idOrSlug}`);
+      const detail = await printfulRequest<PrintfulProductDetail>({ path: `/store/products/${idOrSlug}` });
       return normalizeDetailedStoreProduct(detail);
     } catch {
       // fallback below
@@ -158,4 +193,21 @@ export const getStoreProductByIdOrSlug = async (idOrSlug: string) => {
 
   const products = await getStoreProducts();
   return products.find((item) => item.id === idOrSlug || item.slug === idOrSlug) || null;
+};
+
+export const createPrintfulOrder = async (input: PrintfulCreateOrderInput): Promise<PrintfulCreateOrderResult> => {
+  if (!input.items.length) {
+    throw new Error('Printful order requires at least one item.');
+  }
+
+  return printfulRequest<PrintfulCreateOrderResult>({
+    path: '/orders',
+    method: 'POST',
+    body: {
+      external_id: input.externalId,
+      recipient: input.recipient,
+      items: input.items,
+      confirm: true,
+    },
+  });
 };

--- a/watchyourtemper-site/docs-printful-integration.md
+++ b/watchyourtemper-site/docs-printful-integration.md
@@ -26,11 +26,18 @@
 - Deployment will use a platform that supports `api/` serverless routes.
 - Current phase prepares payment and order automation but does not process live payment yet.
 
-## Next steps
+## Lifecycle status
 
-1. Connect checkout intent response to payment session/intent creation.
-2. Create Printful order after payment confirmation.
-3. Add webhook endpoints for fulfillment/tracking updates.
+1. ✅ Checkout intent is connected to payment-session creation via `POST /api/store/checkout-start`.
+2. ✅ Printful order creation occurs after payment confirmation in Stripe webhook handling.
+3. ✅ Webhook endpoints exist for fulfillment/tracking updates.
+4. ✅ Frontend now uses modal-based variant selection + persistent cart UX.
+
+## Pricing and charge integrity
+
+- Use Printful variant `retail_price` as the canonical catalog price.
+- Recompute line-item totals server-side (product + variant + quantity) before creating Stripe session.
+- Never trust browser-submitted unit prices.
 
 
 ## v2 lifecycle env vars

--- a/watchyourtemper-site/package-lock.json
+++ b/watchyourtemper-site/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@types/node": "^25.6.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1434,6 +1435,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -3511,6 +3522,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/watchyourtemper-site/package.json
+++ b/watchyourtemper-site/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck:api": "tsc -p tsconfig.api.json",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run"
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/watchyourtemper-site/src/components/store/CartDrawer.tsx
+++ b/watchyourtemper-site/src/components/store/CartDrawer.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import type { CartLineItem } from '../../context/CartContext';
+import QuantitySelector from './QuantitySelector';
+
+type Props = {
+  open: boolean;
+  items: CartLineItem[];
+  subtotal: number;
+  totalQuantity: number;
+  currency: string;
+  onClose: () => void;
+  onRemove: (lineKey: string) => void;
+  onUpdateQuantity: (lineKey: string, quantity: number) => void;
+};
+
+const CartDrawer: React.FC<Props> = ({
+  open,
+  items,
+  subtotal,
+  totalQuantity,
+  currency,
+  onClose,
+  onRemove,
+  onUpdateQuantity,
+}) => {
+  return (
+    <>
+      <div className={`store-cart-backdrop ${open ? 'is-open' : ''}`} onClick={onClose} />
+      <aside className={`store-cart ${open ? 'is-open' : ''}`} aria-label="Shopping cart">
+        <header>
+          <h3>Cart ({totalQuantity})</h3>
+          <button type="button" onClick={onClose} aria-label="Close cart">
+            ×
+          </button>
+        </header>
+
+        {!items.length ? (
+          <p className="store-state">Your cart is empty.</p>
+        ) : (
+          <div className="store-cart-list">
+            {items.map((item) => (
+              <article key={item.key} className="store-cart-line">
+                {item.productImage ? <img src={item.productImage} alt={item.productTitle} /> : <div className="store-image-placeholder">IMAGE</div>}
+                <div className="store-cart-line-body">
+                  <h4>{item.productTitle}</h4>
+                  <p>{item.color} • {item.size}</p>
+                  <p>{item.currency} {item.unitPrice.toFixed(2)} each</p>
+                  <QuantitySelector value={item.quantity} onChange={(qty) => onUpdateQuantity(item.key, qty)} />
+                  <button type="button" className="store-text-link" onClick={() => onRemove(item.key)}>
+                    Remove
+                  </button>
+                </div>
+                <p className="store-cart-line-total">{item.currency} {(item.unitPrice * item.quantity).toFixed(2)}</p>
+              </article>
+            ))}
+          </div>
+        )}
+
+        <footer>
+          <p>Subtotal</p>
+          <strong>{currency} {subtotal.toFixed(2)}</strong>
+        </footer>
+      </aside>
+    </>
+  );
+};
+
+export default CartDrawer;

--- a/watchyourtemper-site/src/components/store/ProductCard.tsx
+++ b/watchyourtemper-site/src/components/store/ProductCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { StoreProduct } from '../../types/store';
+
+type Props = {
+  product: StoreProduct;
+  onSelect: (product: StoreProduct) => void;
+};
+
+const ProductCard: React.FC<Props> = ({ product, onSelect }) => {
+  const prices = product.variants.map((variant) => variant.price).filter((price) => Number.isFinite(price));
+  const minPrice = prices.length ? Math.min(...prices) : 0;
+
+  return (
+    <article className="store-card" aria-label={product.title}>
+      {product.image ? (
+        <div className="store-image-wrap">
+          <img className="store-image" src={product.image} alt={product.title} loading="lazy" />
+        </div>
+      ) : (
+        <div className="store-image-placeholder">IMAGE COMING SOON</div>
+      )}
+
+      <div className="store-card-body">
+        <h2 className="store-product-name">{product.title}</h2>
+        <p className="store-product-description">{product.description}</p>
+        <p className="store-product-price">From {product.variants[0]?.currency || 'USD'} {minPrice.toFixed(2)}</p>
+      </div>
+
+      <button className="store-buy-btn" type="button" onClick={() => onSelect(product)}>
+        <span className="btn-label">Select options</span>
+      </button>
+    </article>
+  );
+};
+
+export default ProductCard;

--- a/watchyourtemper-site/src/components/store/ProductOptionsModal.tsx
+++ b/watchyourtemper-site/src/components/store/ProductOptionsModal.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { StoreProduct, StoreVariant } from '../../types/store';
+import QuantitySelector from './QuantitySelector';
+
+type Props = {
+  product: StoreProduct | null;
+  open: boolean;
+  onClose: () => void;
+  onAddToCart: (product: StoreProduct, variant: StoreVariant, quantity: number) => void;
+};
+
+const getFirstAvailableVariant = (product: StoreProduct | null) =>
+  product?.variants.find((variant) => variant.availability) || product?.variants[0] || null;
+
+const ProductOptionsModal: React.FC<Props> = ({ product, open, onClose, onAddToCart }) => {
+  const [color, setColor] = useState('');
+  const [size, setSize] = useState('');
+  const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    if (!open || !product) {
+      return;
+    }
+
+    const first = getFirstAvailableVariant(product);
+    if (first) {
+      setColor(first.color);
+      setSize(first.size);
+    }
+    setQuantity(1);
+  }, [open, product]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  const variantsByColor = useMemo(() => {
+    if (!product) {
+      return new Map<string, StoreVariant[]>();
+    }
+
+    return product.variants.reduce((acc, variant) => {
+      const list = acc.get(variant.color) || [];
+      list.push(variant);
+      acc.set(variant.color, list);
+      return acc;
+    }, new Map<string, StoreVariant[]>());
+  }, [product]);
+
+  const colors = useMemo(() => [...variantsByColor.keys()], [variantsByColor]);
+
+  const sizes = useMemo(() => {
+    if (!product) {
+      return [] as string[];
+    }
+
+    return [...new Set(product.variants.map((variant) => variant.size))];
+  }, [product]);
+
+  const selectedVariant = useMemo(() => {
+    if (!product) {
+      return null;
+    }
+
+    return product.variants.find((variant) => variant.color === color && variant.size === size) || null;
+  }, [color, product, size]);
+
+  if (!open || !product) {
+    return null;
+  }
+
+  return (
+    <div className="store-modal-backdrop" role="presentation" onClick={onClose}>
+      <section className="store-modal" role="dialog" aria-modal="true" aria-label={`Select options for ${product.title}`} onClick={(event) => event.stopPropagation()}>
+        <button className="store-modal-close" type="button" aria-label="Close options" onClick={onClose}>
+          ×
+        </button>
+
+        <div className="store-modal-media">
+          {product.image ? <img src={product.image} alt={product.title} /> : <div className="store-image-placeholder">IMAGE COMING SOON</div>}
+        </div>
+
+        <div className="store-modal-body">
+          <h3>{product.title}</h3>
+          <p className="store-modal-price">
+            {selectedVariant ? `${selectedVariant.currency} ${selectedVariant.price.toFixed(2)}` : 'Select options'}
+          </p>
+          <p className="store-modal-description">{product.description}</p>
+
+          <div className="store-option-group">
+            <p>Color</p>
+            <div className="store-option-row">
+              {colors.map((optionColor) => {
+                const hasAvailable = (variantsByColor.get(optionColor) || []).some((variant) => variant.availability);
+                return (
+                  <button
+                    key={optionColor}
+                    type="button"
+                    className={`store-option-pill ${color === optionColor ? 'is-selected' : ''}`}
+                    disabled={!hasAvailable}
+                    onClick={() => {
+                      setColor(optionColor);
+                      const matching = (variantsByColor.get(optionColor) || []).find((variant) => variant.availability);
+                      if (matching) {
+                        setSize(matching.size);
+                      }
+                    }}
+                  >
+                    {optionColor}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="store-option-group">
+            <p>Size</p>
+            <div className="store-option-row">
+              {sizes.map((optionSize) => {
+                const variant = product.variants.find((item) => item.color === color && item.size === optionSize);
+                return (
+                  <button
+                    key={optionSize}
+                    type="button"
+                    className={`store-option-pill ${size === optionSize ? 'is-selected' : ''}`}
+                    disabled={!variant?.availability}
+                    onClick={() => setSize(optionSize)}
+                  >
+                    {optionSize}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="store-option-group">
+            <p>Quantity</p>
+            <QuantitySelector value={quantity} onChange={setQuantity} />
+          </div>
+
+          <button
+            className="store-buy-btn"
+            type="button"
+            disabled={!selectedVariant || !selectedVariant.availability}
+            onClick={() => {
+              if (!selectedVariant || !selectedVariant.availability) {
+                return;
+              }
+
+              onAddToCart(product, selectedVariant, quantity);
+              onClose();
+            }}
+          >
+            <span className="btn-label">Add to cart</span>
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ProductOptionsModal;

--- a/watchyourtemper-site/src/components/store/QuantitySelector.tsx
+++ b/watchyourtemper-site/src/components/store/QuantitySelector.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+type Props = {
+  value: number;
+  min?: number;
+  max?: number;
+  onChange: (value: number) => void;
+};
+
+const QuantitySelector: React.FC<Props> = ({ value, min = 1, max = 20, onChange }) => {
+  const nextValue = Math.min(max, Math.max(min, value));
+
+  return (
+    <div className="store-qty" aria-label="Quantity selector">
+      <button type="button" onClick={() => onChange(Math.max(min, nextValue - 1))} disabled={nextValue <= min}>
+        −
+      </button>
+      <span>{nextValue}</span>
+      <button type="button" onClick={() => onChange(Math.min(max, nextValue + 1))} disabled={nextValue >= max}>
+        +
+      </button>
+    </div>
+  );
+};
+
+export default QuantitySelector;

--- a/watchyourtemper-site/src/context/CartContext.tsx
+++ b/watchyourtemper-site/src/context/CartContext.tsx
@@ -1,0 +1,142 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { StoreProduct, StoreVariant } from '../types/store';
+
+export type CartLineItem = {
+  key: string;
+  productId: string;
+  variantId: string;
+  productTitle: string;
+  productImage: string;
+  variantName: string;
+  size: string;
+  color: string;
+  unitPrice: number;
+  currency: string;
+  quantity: number;
+};
+
+type CartContextValue = {
+  items: CartLineItem[];
+  totalQuantity: number;
+  subtotal: number;
+  currency: string;
+  addItem: (input: { product: StoreProduct; variant: StoreVariant; quantity: number }) => void;
+  removeItem: (lineKey: string) => void;
+  updateQuantity: (lineKey: string, quantity: number) => void;
+  clearCart: () => void;
+};
+
+const CART_STORAGE_KEY = 'wyt-store-cart-v1';
+
+const CartContext = createContext<CartContextValue | null>(null);
+
+const makeLineKey = (productId: string, variantId: string) => `${productId}::${variantId}`;
+
+const sanitizeQuantity = (value: number) => Math.max(1, Math.min(20, Math.floor(value)));
+
+export const CartProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [items, setItems] = useState<CartLineItem[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(CART_STORAGE_KEY);
+      if (!raw) {
+        return;
+      }
+
+      const parsed = JSON.parse(raw) as CartLineItem[];
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+
+      setItems(
+        parsed
+          .filter((item) => item && typeof item === 'object' && typeof item.key === 'string')
+          .map((item) => ({ ...item, quantity: sanitizeQuantity(item.quantity || 1) })),
+      );
+    } catch {
+      // ignore malformed persisted cart
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+  }, [items]);
+
+  const value = useMemo<CartContextValue>(() => {
+    const addItem: CartContextValue['addItem'] = ({ product, variant, quantity }) => {
+      setItems((current) => {
+        const key = makeLineKey(product.id, variant.id);
+        const existing = current.find((item) => item.key === key);
+
+        if (existing) {
+          return current.map((item) =>
+            item.key === key ? { ...item, quantity: sanitizeQuantity(item.quantity + quantity) } : item,
+          );
+        }
+
+        const nextLine: CartLineItem = {
+          key,
+          productId: product.id,
+          variantId: variant.id,
+          productTitle: product.title,
+          productImage: product.image,
+          variantName: variant.name,
+          size: variant.size,
+          color: variant.color,
+          unitPrice: variant.price,
+          currency: variant.currency,
+          quantity: sanitizeQuantity(quantity),
+        };
+
+        return [...current, nextLine];
+      });
+    };
+
+    const removeItem: CartContextValue['removeItem'] = (lineKey) => {
+      setItems((current) => current.filter((item) => item.key !== lineKey));
+    };
+
+    const updateQuantity: CartContextValue['updateQuantity'] = (lineKey, quantity) => {
+      const nextQuantity = sanitizeQuantity(quantity);
+      setItems((current) => current.map((item) => (item.key === lineKey ? { ...item, quantity: nextQuantity } : item)));
+    };
+
+    const clearCart = () => setItems([]);
+
+    const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0);
+    const subtotal = Number(items.reduce((sum, item) => sum + item.unitPrice * item.quantity, 0).toFixed(2));
+    const currency = items[0]?.currency || 'USD';
+
+    return {
+      items,
+      totalQuantity,
+      subtotal,
+      currency,
+      addItem,
+      removeItem,
+      updateQuantity,
+      clearCart,
+    };
+  }, [items]);
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+};
+
+export const useCart = () => {
+  const value = useContext(CartContext);
+  if (!value) {
+    throw new Error('useCart must be used within CartProvider');
+  }
+
+  return value;
+};

--- a/watchyourtemper-site/src/lib/storeApi.ts
+++ b/watchyourtemper-site/src/lib/storeApi.ts
@@ -34,3 +34,32 @@ export const createCheckoutIntent = async (input: {
   const payload = await parseJson<{ intent: CheckoutIntent }>(response);
   return payload.intent;
 };
+
+export type CheckoutStartInput = {
+  productId: string;
+  variantId: string;
+  quantity: number;
+  customer: { email: string };
+  shippingAddress: {
+    name: string;
+    line1: string;
+    line2?: string;
+    city: string;
+    state: string;
+    postalCode: string;
+    country: string;
+  };
+};
+
+export const createCheckoutStart = async (input: CheckoutStartInput) => {
+  const response = await fetch(`${API_BASE}/api/store/checkout-start`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(input),
+  });
+
+  const payload = await parseJson<{ payment: { checkoutUrl: string } }>(response);
+  return payload;
+};

--- a/watchyourtemper-site/src/main.tsx
+++ b/watchyourtemper-site/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { CartProvider } from './context/CartContext.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <CartProvider>
+      <App />
+    </CartProvider>
   </StrictMode>,
 )

--- a/watchyourtemper-site/src/pages/Store.tsx
+++ b/watchyourtemper-site/src/pages/Store.tsx
@@ -1,31 +1,22 @@
 import { useEffect, useMemo, useState } from 'react';
-import { createCheckoutIntent, fetchStoreProducts } from '../lib/storeApi';
-import { getColorOptions, getSelectedVariant as getSelectedVariantByChoice, getSizeOptions } from '../lib/storeSelection';
+import CartDrawer from '../components/store/CartDrawer';
+import ProductCard from '../components/store/ProductCard';
+import ProductOptionsModal from '../components/store/ProductOptionsModal';
+import { useCart } from '../context/CartContext';
+import { fetchStoreProducts } from '../lib/storeApi';
 import type { StoreProduct, StoreVariant } from '../types/store';
 import '../styles/index.css';
-
-type SelectionState = {
-  color: string;
-  size: string;
-  quantity: number;
-};
-
-const getInitialSelection = (variants: StoreVariant[]): SelectionState => {
-  const firstAvailable = variants.find((variant) => variant.availability) || variants[0];
-  return {
-    color: firstAvailable?.color || 'Default',
-    size: firstAvailable?.size || 'Default',
-    quantity: 1,
-  };
-};
 
 const Store: React.FC = () => {
   const [products, setProducts] = useState<StoreProduct[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [statusByProduct, setStatusByProduct] = useState<Record<string, string>>({});
-  const [busyByProduct, setBusyByProduct] = useState<Record<string, boolean>>({});
-  const [selectionByProduct, setSelectionByProduct] = useState<Record<string, SelectionState>>({});
+  const [activeProduct, setActiveProduct] = useState<StoreProduct | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isCartOpen, setIsCartOpen] = useState(false);
+  const [toast, setToast] = useState('');
+
+  const { items, subtotal, totalQuantity, currency, addItem, removeItem, updateQuantity } = useCart();
 
   useEffect(() => {
     document.title = 'watchyourtemper | Store';
@@ -39,12 +30,6 @@ const Store: React.FC = () => {
       try {
         const loaded = await fetchStoreProducts();
         setProducts(loaded);
-        setSelectionByProduct(
-          loaded.reduce<Record<string, SelectionState>>((acc, product) => {
-            acc[product.id] = getInitialSelection(product.variants);
-            return acc;
-          }, {}),
-        );
       } catch (fetchError) {
         setError(fetchError instanceof Error ? fetchError.message : 'Unable to load products.');
       } finally {
@@ -55,78 +40,14 @@ const Store: React.FC = () => {
     void loadProducts();
   }, []);
 
-  const getSelectedVariant = (product: StoreProduct): StoreVariant | null => {
-    const selection = selectionByProduct[product.id];
-    if (!selection) {
-      return null;
-    }
-
-    return getSelectedVariantByChoice(product.variants, selection.color, selection.size);
-  };
-
-  const handleSelectionChange = (product: StoreProduct, next: Partial<SelectionState>) => {
-    setSelectionByProduct((current) => {
-      const existing = current[product.id] || getInitialSelection(product.variants);
-      const draft = { ...existing, ...next };
-      const matchingVariant = product.variants.find(
-        (variant) => variant.color === draft.color && variant.size === draft.size,
-      );
-
-      if (!matchingVariant) {
-        const fallbackVariant =
-          product.variants.find((variant) => variant.color === draft.color && variant.availability) ||
-          product.variants.find((variant) => variant.availability) ||
-          product.variants[0];
-
-        return {
-          ...current,
-          [product.id]: {
-            ...draft,
-            color: fallbackVariant?.color || draft.color,
-            size: fallbackVariant?.size || draft.size,
-          },
-        };
-      }
-
-      return {
-        ...current,
-        [product.id]: draft,
-      };
-    });
-  };
-
-  const handleCheckout = async (product: StoreProduct) => {
-    const selectedVariant = getSelectedVariant(product);
-    const selection = selectionByProduct[product.id];
-
-    if (!selectedVariant || !selection) {
-      setStatusByProduct((current) => ({ ...current, [product.id]: 'Select an available variant.' }));
+  useEffect(() => {
+    if (!toast) {
       return;
     }
 
-    setBusyByProduct((current) => ({ ...current, [product.id]: true }));
-    setStatusByProduct((current) => ({ ...current, [product.id]: '' }));
-
-    try {
-      const intent = await createCheckoutIntent({
-        productId: product.id,
-        variantId: selectedVariant.id,
-        quantity: selection.quantity,
-      });
-
-      setStatusByProduct((current) => ({
-        ...current,
-        [product.id]: `Ready for payment: ${intent.lineItem.quantity} x ${intent.lineItem.variantName} (${intent.lineItem.currency} ${intent.lineItem.subtotal.toFixed(2)})`,
-      }));
-    } catch (checkoutError) {
-      setStatusByProduct((current) => ({
-        ...current,
-        [product.id]: checkoutError instanceof Error ? checkoutError.message : 'Unable to start checkout.',
-      }));
-    } finally {
-      setBusyByProduct((current) => ({ ...current, [product.id]: false }));
-    }
-  };
+    const id = window.setTimeout(() => setToast(''), 2000);
+    return () => window.clearTimeout(id);
+  }, [toast]);
 
   const content = useMemo(() => {
     if (loading) {
@@ -143,128 +64,58 @@ const Store: React.FC = () => {
 
     return (
       <section className="store-grid" aria-label="Store products">
-        {products.map((product, index) => {
-          const selection = selectionByProduct[product.id] || getInitialSelection(product.variants);
-          const selectedVariant = getSelectedVariant(product);
-          const colors = getColorOptions(product.variants);
-          const sizes = getSizeOptions(product.variants, selection.color);
-
-          const variantAvailable = Boolean(selectedVariant?.availability);
-          const hasImage = Boolean(product.image);
-
-          return (
-            <article
-              key={product.id}
-              className="store-card"
-              style={{
-                ['--flicker-delay' as string]: `${(index % 4) * 0.08}s`,
-                ['--hover-delay' as string]: `${60 + ((index * 17) % 55)}ms`,
-              }}
-            >
-              {hasImage ? (
-                <div className="store-image-wrap">
-                  <img className="store-image" src={product.image} alt={product.title} />
-                </div>
-              ) : (
-                <div className="store-image-placeholder" aria-label="Product image placeholder">
-                  IMAGE COMING SOON
-                </div>
-              )}
-
-              <div className="store-card-body">
-                <h2 className="store-product-name" data-text={product.title}>
-                  {product.title}
-                </h2>
-                <p className="store-product-description">{product.description}</p>
-                <p className="store-product-price">
-                  {selectedVariant
-                    ? `${selectedVariant.currency} ${selectedVariant.price.toFixed(2)}`
-                    : 'Price unavailable'}
-                </p>
-
-                <div className="store-variant-row">
-                  <label>
-                    Color
-                    <select
-                      value={selection.color}
-                      onChange={(event) =>
-                        handleSelectionChange(product, {
-                          color: event.target.value,
-                          size: product.variants.find((variant) => variant.color === event.target.value)?.size ||
-                            selection.size,
-                        })
-                      }
-                    >
-                      {colors.map((color) => (
-                        <option key={color} value={color}>
-                          {color}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-
-                  <label>
-                    Size
-                    <select
-                      value={selection.size}
-                      onChange={(event) => handleSelectionChange(product, { size: event.target.value })}
-                    >
-                      {sizes.map((size) => {
-                        const optionVariant = product.variants.find(
-                          (variant) => variant.color === selection.color && variant.size === size,
-                        );
-                        return (
-                          <option key={size} value={size} disabled={!optionVariant?.availability}>
-                            {size}
-                            {optionVariant?.availability ? '' : ' (Unavailable)'}
-                          </option>
-                        );
-                      })}
-                    </select>
-                  </label>
-
-                  <label>
-                    Qty
-                    <input
-                      type="number"
-                      min={1}
-                      max={20}
-                      value={selection.quantity}
-                      onChange={(event) => {
-                        const nextQty = Number(event.target.value);
-                        handleSelectionChange(product, {
-                          quantity: Number.isInteger(nextQty)
-                            ? Math.min(20, Math.max(1, nextQty))
-                            : selection.quantity,
-                        });
-                      }}
-                    />
-                  </label>
-                </div>
-              </div>
-
-              <button
-                className={`store-buy-btn ${!variantAvailable ? 'disabled' : ''}`}
-                type="button"
-                disabled={!variantAvailable || busyByProduct[product.id]}
-                onClick={() => void handleCheckout(product)}
-              >
-                <span className="btn-label">
-                  {busyByProduct[product.id] ? 'PROCESSING…' : 'START CHECKOUT'}
-                </span>
-              </button>
-
-              {statusByProduct[product.id] ? (
-                <p className="store-intent-status">{statusByProduct[product.id]}</p>
-              ) : null}
-            </article>
-          );
-        })}
+        {products.map((product) => (
+          <ProductCard
+            key={product.id}
+            product={product}
+            onSelect={(selected) => {
+              setActiveProduct(selected);
+              setIsModalOpen(true);
+            }}
+          />
+        ))}
       </section>
     );
-  }, [busyByProduct, error, loading, products, selectionByProduct, statusByProduct]);
+  }, [error, loading, products]);
 
-  return <main className="store-page">{content}</main>;
+  const handleAddToCart = (product: StoreProduct, variant: StoreVariant, quantity: number) => {
+    addItem({ product, variant, quantity });
+    setToast('Added to cart');
+    setIsCartOpen(true);
+  };
+
+  return (
+    <main className="store-page">
+      <header className="store-toolbar">
+        <p>APPAREL RITUALS</p>
+        <button className="store-cart-open-btn" type="button" onClick={() => setIsCartOpen(true)}>
+          Cart ({totalQuantity})
+        </button>
+      </header>
+
+      {content}
+
+      <ProductOptionsModal
+        product={activeProduct}
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onAddToCart={handleAddToCart}
+      />
+
+      <CartDrawer
+        open={isCartOpen}
+        items={items}
+        subtotal={subtotal}
+        totalQuantity={totalQuantity}
+        currency={currency}
+        onClose={() => setIsCartOpen(false)}
+        onRemove={removeItem}
+        onUpdateQuantity={updateQuantity}
+      />
+
+      {toast ? <div className="store-toast">{toast}</div> : null}
+    </main>
+  );
 };
 
 export default Store;

--- a/watchyourtemper-site/src/styles/index.css
+++ b/watchyourtemper-site/src/styles/index.css
@@ -709,8 +709,8 @@ h2 {
 .store-grid {
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
-  gap: clamp(1rem, 1.5vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 250px), 1fr));
+  gap: clamp(1rem, 1.7vw, 1.8rem);
   align-items: start;
 }
 
@@ -723,7 +723,7 @@ h2 {
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.85rem;
   min-width: 0;
   transition:
     border-color 0.18s steps(2, end),
@@ -805,44 +805,15 @@ h2 {
 .store-card-body {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.4rem;
+  min-height: 128px;
 }
 
 .store-product-name {
-  position: relative;
   font-size: 1.05rem;
   letter-spacing: 0.1em;
   margin: 0;
   text-transform: uppercase;
-}
-
-.store-product-name::before,
-.store-product-name::after {
-  content: attr(data-text);
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0;
-}
-
-.store-product-name::before {
-  color: rgba(255, 255, 255, 0.35);
-  transform: translateX(-1px);
-}
-
-.store-product-name::after {
-  color: rgba(125, 255, 136, 0.55);
-  transform: translateX(1.5px);
-}
-
-.store-card:hover .store-product-name {
-  animation: title-jitter 0.24s steps(2, end) 1;
-}
-
-.store-card:hover .store-product-name::before,
-.store-card:hover .store-product-name::after {
-  opacity: 1;
-  animation: text-shift 0.22s steps(2, end) 1;
 }
 
 .store-product-description,
@@ -905,34 +876,6 @@ h2 {
   background: transparent;
 }
 
-
-.store-variant-row {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.55rem;
-  margin-top: 0.55rem;
-}
-
-.store-variant-row label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.28rem;
-  font-size: 0.66rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #a7a7a7;
-}
-
-.store-variant-row select,
-.store-variant-row input {
-  background: #0a0a0a;
-  border: 1px solid #2b2b2b;
-  color: #d6d6d6;
-  font-size: 0.78rem;
-  padding: 0.38rem 0.45rem;
-  font-family: inherit;
-}
-
 .store-state {
   text-align: center;
   color: #a7a7a7;
@@ -948,6 +891,280 @@ h2 {
   font-size: 0.72rem;
   color: #9ccda5;
   letter-spacing: 0.04em;
+}
+
+.store-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.store-toolbar p {
+  margin: 0;
+  letter-spacing: 0.16em;
+  color: #a3a3a3;
+  font-size: 0.74rem;
+}
+
+.store-cart-open-btn {
+  border: 1px solid #3a3a3a;
+  background: #090909;
+  color: #e3e3e3;
+  padding: 0.55rem 0.8rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.store-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(0, 0, 0, 0.7);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.store-modal {
+  width: min(900px, 100%);
+  max-height: min(90vh, 920px);
+  overflow: auto;
+  border: 1px solid #2f2f2f;
+  background: #080808;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  position: relative;
+}
+
+.store-modal-close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  border: 1px solid #2f2f2f;
+  background: #0b0b0b;
+  color: #fff;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+}
+
+.store-modal-media img,
+.store-modal-media .store-image-placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  object-fit: cover;
+}
+
+.store-modal-body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.store-modal-body h3 {
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.store-modal-price {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.store-modal-description {
+  margin: 0;
+  color: #a1a1a1;
+  font-size: 0.86rem;
+}
+
+.store-option-group p {
+  margin: 0 0 0.4rem;
+  font-size: 0.72rem;
+  color: #9a9a9a;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.store-option-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.store-option-pill {
+  border: 1px solid #323232;
+  background: #080808;
+  color: #efefef;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.store-option-pill.is-selected {
+  border-color: #7dff88;
+  color: #7dff88;
+}
+
+.store-option-pill:disabled {
+  color: #6a6a6a;
+  border-color: #202020;
+  cursor: not-allowed;
+}
+
+.store-qty {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #2e2e2e;
+}
+
+.store-qty button {
+  border: 0;
+  background: #101010;
+  color: #fff;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+}
+
+.store-qty span {
+  width: 2rem;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.store-cart-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 35;
+}
+
+.store-cart-backdrop.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.store-cart {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(460px, 95vw);
+  height: 100vh;
+  z-index: 45;
+  transform: translateX(100%);
+  transition: transform 0.22s ease;
+  background: #080808;
+  border-left: 1px solid #2b2b2b;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.store-cart.is-open {
+  transform: translateX(0);
+}
+
+.store-cart header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.store-cart header h3 {
+  margin: 0;
+}
+
+.store-cart header button {
+  border: 1px solid #2e2e2e;
+  background: #0f0f0f;
+  color: #fff;
+  width: 2rem;
+  height: 2rem;
+}
+
+.store-cart-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  overflow: auto;
+}
+
+.store-cart-line {
+  display: grid;
+  grid-template-columns: 84px 1fr auto;
+  gap: 0.6rem;
+  border: 1px solid #1d1d1d;
+  padding: 0.5rem;
+}
+
+.store-cart-line img {
+  width: 84px;
+  height: 84px;
+  object-fit: cover;
+}
+
+.store-cart-line-body h4,
+.store-cart-line-body p {
+  margin: 0;
+}
+
+.store-cart-line-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.74rem;
+}
+
+.store-text-link {
+  border: 0;
+  background: none;
+  color: #a7a7a7;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.store-cart-line-total {
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.store-cart footer {
+  margin-top: auto;
+  border-top: 1px solid #212121;
+  padding-top: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.store-cart footer p {
+  margin: 0;
+}
+
+.store-toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 50;
+  background: #0d0d0d;
+  border: 1px solid #335735;
+  color: #cde9d0;
+  padding: 0.6rem 0.8rem;
+  letter-spacing: 0.06em;
+  font-size: 0.8rem;
 }
 
 /* ================= STORE: ANIMATIONS ================= */
@@ -1135,5 +1352,28 @@ h2 {
 
   .store-page {
     padding-bottom: 2rem;
+  }
+
+  .store-modal {
+    grid-template-columns: 1fr;
+  }
+
+  .store-modal-media img,
+  .store-modal-media .store-image-placeholder {
+    min-height: 220px;
+  }
+
+  .store-cart-line {
+    grid-template-columns: 68px 1fr;
+  }
+
+  .store-cart-line img {
+    width: 68px;
+    height: 68px;
+  }
+
+  .store-cart-line-total {
+    grid-column: 2;
+    justify-self: end;
   }
 }

--- a/watchyourtemper-site/tsconfig.api.json
+++ b/watchyourtemper-site/tsconfig.api.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["api/**/*.ts"]
+}


### PR DESCRIPTION
### Motivation

- Move store logic server-side to protect `PRINTFUL_TOKEN`, derive prices from Printful, and prepare automated order creation and webhook handling for payments/fulfillment.
- Improve the shopping experience with a persistent cart, modal variant selection, and clearer client-side flows while preventing client-side price tampering.

### Description

- Extended `api/_lib/printfulClient.ts` to use a generic `printfulRequest` signature with method/body support, added typed order shapes, exported `normalizeStoreProduct`, and implemented `createPrintfulOrder` (POST `/orders`).
- Updated docs and `README.md` to describe v2 lifecycle, new endpoints (`POST /api/store/checkout-start`, `POST /api/webhooks/payment`, and `POST /api/webhooks/printful`) and clarified pricing as Printful `retail_price` server-side.
- Added frontend cart infrastructure including `CartContext` (`src/context/CartContext.tsx`), UI components `ProductCard`, `ProductOptionsModal`, `CartDrawer`, and `QuantitySelector`, refactored `src/pages/Store.tsx` to use modal + cart UX, wrapped app with `CartProvider` in `src/main.tsx`, and added client API helper `createCheckoutStart` in `src/lib/storeApi.ts`.
- Styling and project config updates including large CSS additions for the store UI (`src/styles/index.css`), package changes to add `@types/node` and a new `typecheck:api` script, and a new `tsconfig.api.json` for API type checks.

### Testing

- No automated test runs were observed as part of this rollout.
- A new `typecheck:api` npm script and `tsconfig.api.json` were added to enable API type checking with `tsc -p tsconfig.api.json`, but this script was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda1d0da94832780a5efe1b587f358)