### PR TITLE
Fix cart drawer offset, move mute toggle, and add checkout CTA

### DIFF
--- a/watchyourtemper-site/src/components/store/CartDrawer.tsx
+++ b/watchyourtemper-site/src/components/store/CartDrawer.tsx
@@ -8,7 +8,9 @@ type Props = {
   subtotal: number;
   totalQuantity: number;
   currency: string;
+  checkoutDisabled?: boolean;
   onClose: () => void;
+  onCheckout: () => void;
   onRemove: (lineKey: string) => void;
   onUpdateQuantity: (lineKey: string, quantity: number) => void;
 };
@@ -19,7 +21,9 @@ const CartDrawer: React.FC<Props> = ({
   subtotal,
   totalQuantity,
   currency,
+  checkoutDisabled = false,
   onClose,
+  onCheckout,
   onRemove,
   onUpdateQuantity,
 }) => {
@@ -57,8 +61,18 @@ const CartDrawer: React.FC<Props> = ({
         )}
 
         <footer>
-          <p>Subtotal</p>
-          <strong>{currency} {subtotal.toFixed(2)}</strong>
+          <div className="store-cart-summary">
+            <p>Subtotal</p>
+            <strong>{currency} {subtotal.toFixed(2)}</strong>
+          </div>
+          <button
+            type="button"
+            className="store-checkout-btn"
+            onClick={onCheckout}
+            disabled={checkoutDisabled}
+          >
+            Checkout
+          </button>
         </footer>
       </aside>
     </>

--- a/watchyourtemper-site/src/pages/Store.tsx
+++ b/watchyourtemper-site/src/pages/Store.tsx
@@ -84,6 +84,10 @@ const Store: React.FC = () => {
     setIsCartOpen(true);
   };
 
+  const handleCheckout = () => {
+    setToast('Checkout form is coming next. For now, cart review is available.');
+  };
+
   return (
     <main className="store-page">
       <header className="store-toolbar">
@@ -108,7 +112,9 @@ const Store: React.FC = () => {
         subtotal={subtotal}
         totalQuantity={totalQuantity}
         currency={currency}
+        checkoutDisabled={!items.length}
         onClose={() => setIsCartOpen(false)}
+        onCheckout={handleCheckout}
         onRemove={removeItem}
         onUpdateQuantity={updateQuantity}
       />

--- a/watchyourtemper-site/src/styles/index.css
+++ b/watchyourtemper-site/src/styles/index.css
@@ -16,7 +16,7 @@
 .route-shell {
   --nav-offset: var(--nav-height);
   min-height: 100dvh;
-  padding-top: var(--nav-offset);
+  padding-top: var(--nav-offset, var(--nav-height));
 }
 
 .route-shell--overlay {
@@ -293,7 +293,7 @@ h2 {
 #mute-btn {
   position: fixed;
   bottom: 20px;
-  right: 20px;
+  left: 20px;
   z-index: 1001;
   background: rgba(0, 0, 0, 0.5);
   border: none;
@@ -697,7 +697,7 @@ h2 {
   --panel-border: #242424;
   --panel-inline: #111;
   --log-text: #8d8d8d;
-  min-height: calc(100dvh - var(--nav-offset));
+  min-height: calc(100dvh - var(--nav-offset, var(--nav-height)));
   width: min(100%, 2200px);
   margin: 0 auto;
   padding: 1.5rem clamp(1rem, 2.5vw, 3rem) 3rem;
@@ -1056,10 +1056,10 @@ h2 {
 
 .store-cart {
   position: fixed;
-  top: 0;
+  top: var(--nav-offset, var(--nav-height));
   right: 0;
   width: min(460px, 95vw);
-  height: 100vh;
+  height: calc(100dvh - var(--nav-offset, var(--nav-height)));
   z-index: 45;
   transform: translateX(100%);
   transition: transform 0.22s ease;
@@ -1145,6 +1145,11 @@ h2 {
   margin-top: auto;
   border-top: 1px solid #212121;
   padding-top: 0.75rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.store-cart-summary {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -1152,6 +1157,24 @@ h2 {
 
 .store-cart footer p {
   margin: 0;
+}
+
+.store-checkout-btn {
+  width: 100%;
+  border: 1px solid #3a3a3a;
+  background: #131313;
+  color: #e8e8e8;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.7rem 0.8rem;
+  cursor: pointer;
+}
+
+.store-checkout-btn:disabled {
+  cursor: not-allowed;
+  color: #6b6b6b;
+  border-color: #2a2a2a;
+  background: #0c0c0c;
 }
 
 .store-toast {


### PR DESCRIPTION
### Motivation
- Ensure the cart drawer is positioned below the fixed navbar and sized to the remaining viewport so it matches the store page spacing and doesn’t overlap the nav.
- Move the global mute toggle to the bottom-left as requested by the design/UI feedback.
- Provide an obvious checkout CTA in the cart so users can proceed from cart review toward payment, and wire a simple handler to surface next-step feedback.

### Description
- Adjusted global styles to offset the route and cart with `--nav-offset` fallbacks and sized the cart to `calc(100dvh - var(--nav-offset, var(--nav-height)))`, and moved `#mute-btn` from the bottom-right to `left: 20px` in `src/styles/index.css`.
- Added a subtotal summary wrapper and a full-width `Checkout` button to the cart footer and new `.store-checkout-btn` and `.store-cart-summary` styles in `src/components/store/CartDrawer.tsx` and `src/styles/index.css`.
- Extended `CartDrawer` props with `checkoutDisabled?: boolean` and `onCheckout: () => void`, and wired a `handleCheckout` that shows a temporary toast message in `src/pages/Store.tsx` while the full checkout form flow is pending.
- Files changed: `watchyourtemper-site/src/styles/index.css`, `watchyourtemper-site/src/components/store/CartDrawer.tsx`, and `watchyourtemper-site/src/pages/Store.tsx`.

### Testing
- Ran `npm --prefix watchyourtemper-site run build` and the production build completed successfully (`vite build` succeeded). 
- Ran `npm --prefix watchyourtemper-site run lint` which failed due to existing `@typescript-eslint/no-explicit-any` errors in API route files that were not modified by this PR. 
- Ran `npm --prefix watchyourtemper-site install` as part of validation and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda819d000832783f04fa3204b44b0)